### PR TITLE
Fix background height

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@ body, html {
     background-image: url("Background.jpg");
   
     /* Full height */
-    height: 100%;
+    min-height: 100%;
   
     /* Center and scale the image nicely */
     background-position: center;


### PR DESCRIPTION
### A small bug fix for the background

Fixes #16 

### How it works

By setting the [`height`](https://developer.mozilla.org/en-US/docs/Web/CSS/height) to 100%, when the body content grows with the new contents in the list the initial 100% height won't fit the new one. With [`min-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-height) it sets a minimum of 100% but allows growth no matter how big.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)